### PR TITLE
chore: update pytest to 9.0.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -181,26 +181,41 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pytest"
-version = "8.2.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343"},
-    {file = "pytest-8.2.2.tar.gz", hash = "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=1.5,<2.0"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -274,4 +289,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2e32e1615450e7f575938759eeccf84d928a4f7ecdcdd8de13fbf03baaf7a5f7"
+content-hash = "99f693b24c31a42bb1df1ebea0f0dc3fe5e5a761c27de59df6df09215a18dc31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ toml = "^0.10.2"
 pandas = "^2.2.2"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.2.2"
+pytest = "^9.0.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary

- Updates the Poetry dev dependency constraint for `pytest` from `^8.2.2` to `^9.0.3`.
- Regenerates `poetry.lock` with `pytest 9.0.3` and its updated dependency metadata, including the new direct `pygments` dependency.
- Addresses the Dependabot-reported pytest CVE by ensuring the locked pytest version is at or above `9.0.3`.

## Validation

- `poetry check` passes with Poetry 1.8.3 on the cleaned PR branch.
- `poetry run pytest` uses `pytest-9.0.3`, but collection fails because `testrium` is not importable through the generated pytest console entry point in this environment.
- `poetry run python -m pytest` imports the package, then reports duplicate test module basenames for `tests/*/test_case.py`.
- `poetry run python -m pytest --import-mode=importlib` collects and runs 4 tests: 3 pass and the existing sample `tests/example_test/test_case.py::test_failure` fails as written (`1 + 1 should be 3`).